### PR TITLE
Use correct config file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Run these commands at a command prompt.
 ```bash
 git clone https://github.com/unicef/aggregate_airport_mobility.git
 cd aggregate_airport_mobility
-cp config-sample.js config.js
+cp config_sample.js config.js
 npm install
 ```
 


### PR DESCRIPTION
In the README, we incorrectly use the wrong config file name, as compared to what's in the repo.

Since I think this is an "easyfix" type of bug, I'll go ahead and merge this PR after the CI build finishes.