### PR TITLE
Add TravisCI status badge at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Aggregate Airport Mobility
 ==========================
 
+[![Build Status](https://travis-ci.org/unicef/aggregate_airport_mobility.svg?branch=master)](https://travis-ci.org/unicef/aggregate_airport_mobility)
+
 Aggregate Amadeus mobility data by administrative boundary to produce CSV output
 
 


### PR DESCRIPTION
I grabbed the status badge for CI builds on Travis and added it to the top of the README. It's a nice indicator of the stability of master branch and also shows that we have CI in place.

Like my last PR, this is a fairly simple change, so after the check finishes, I'll go ahead and merge this in.